### PR TITLE
ci: bump goreleaser-action v6 to v7 for Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           go-version: "1.25"
           cache: true
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: "~> v2"


### PR DESCRIPTION
v7.0.0 switched to Node 24 + ESM, removing the Node 20 deprecation warning on the release workflow.